### PR TITLE
feat: move slotProps into defineMetadata & added index calculation

### DIFF
--- a/packages/core/src/components/DynamicFormItem.vue
+++ b/packages/core/src/components/DynamicFormItem.vue
@@ -440,6 +440,7 @@ function updateArrayValue(_value: unknown) {
       :slot-props
       :required
       :disabled
+      :index
       :can-add-items
       :can-remove-items="_canRemoveItems"
       :add-item
@@ -448,10 +449,11 @@ function updateArrayValue(_value: unknown) {
       <template #default="slotProps">
         <template v-if="isParent">
           <DynamicFormItem
-            v-for="child in computedField.children"
+            v-for="(child, index) in computedField.children"
             :key="child.path"
             :field-metadata="(child as InternalMetadata)"
             :path-override="itemPath"
+            :index
             :template
             :slot-props
             :min-occurs-override="_minOccursOverride"
@@ -469,6 +471,7 @@ function updateArrayValue(_value: unknown) {
             :slot-props
             :required
             :disabled
+            :index
             :can-add-items
             :can-remove-items="_canRemoveItems"
             :add-item
@@ -478,10 +481,11 @@ function updateArrayValue(_value: unknown) {
       </template>
       <template v-if="showAttributes" #attributes="slotProps">
         <DynamicFormItem
-          v-for="attribute in computedField.attributes"
+          v-for="(attribute, index) in computedField.attributes"
           :key="attribute.path"
           :field-metadata="(attribute as InternalMetadata)"
           :path-override="path"
+          :index
           :template
           :slot-props
           :min-occurs-override="_minOccursOverride"

--- a/packages/core/src/components/DynamicFormItemArray.vue
+++ b/packages/core/src/components/DynamicFormItemArray.vue
@@ -238,22 +238,22 @@ function guardAndNotifyItemUpdate(value: any, index: number) {
   >
     <template #default="slotProps">
       <DynamicFormItem
-        v-for="({ key }, index) in fields ?? []"
+        v-for="({ key }, arrayIndex) in fields ?? []"
         :key="key"
         :field-metadata
-        :path-override="`${path}[${index}]`"
-        :index
+        :path-override="`${path}[${arrayIndex}]`"
+        :index="arrayIndex"
         :template="template"
         :slot-props
         :max-occurs-override="_maxOccursOverride"
         :can-add-items="_canAddItems"
         :can-remove-items="_canRemoveItems"
         :add-item="_addItem"
-        :remove-item="() => _removeItem(index)"
+        :remove-item="() => _removeItem(arrayIndex)"
         part-of-array-field
         is-array-override="single"
 
-        @update:model-value="guardAndNotifyItemUpdate($event, index)"
+        @update:model-value="guardAndNotifyItemUpdate($event, arrayIndex)"
         @blur="handleBlur"
       />
     </template>

--- a/packages/core/src/components/DynamicFormItemChoice.vue
+++ b/packages/core/src/components/DynamicFormItemChoice.vue
@@ -298,6 +298,7 @@ function updateChildValue(
     :field-metadata
     :field-context
     :required
+    :index
     :disabled
     :slot-props
     :can-add-items
@@ -323,6 +324,7 @@ function updateChildValue(
         :key="child.name"
         :field-metadata="(child as InternalMetadata)"
         :path-override
+        :index
         :template
         :slot-props
         :min-occurs-override="occurrences[index]?.overrideChildMinOccurrences"

--- a/packages/core/src/components/DynamicFormTemplate.vue
+++ b/packages/core/src/components/DynamicFormTemplate.vue
@@ -5,7 +5,7 @@
 >
 import type { FieldContext as _FieldContext } from 'vee-validate';
 import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
-import type { FieldMetadata } from '@/types/FieldMetadata';
+import type { FieldMetadata, TemplatePropsType } from '@/types/FieldMetadata';
 import type { MetadataConfiguration } from '@/types/MetadataConfiguration';
 import { computed, useAttrs } from 'vue';
 import { camelize } from '@/utils/camelize';
@@ -46,15 +46,15 @@ export interface Attributes<
 > {
   type: TMetadataConfiguration['fieldTypes'][number] | 'default' | 'array' | 'choice'
   /** The metadata you configured for this field. */
-  fieldMetadata: FieldMetadata<
+  fieldMetadata: TemplatePropsType<FieldMetadata<
     TMetadataConfiguration['fieldTypes'][number],
     TMetadataConfiguration['extendedProperties']
-  >
+  >>
   /** Whether the field is required. */
   required: boolean
   /** Whether the field is disabled (maxOccurs = 0). */
   disabled: boolean
-  /** The position of this item within its parent array field. */
+  /** The position of this item within its parent, that can be its position in the children or choice collection or its index in an array field. */
   index: number
   /**
    * Whether a new array item can be added.
@@ -70,6 +70,11 @@ export interface Attributes<
   addItem: () => void
   /** Removes this item from the parent array field. */
   removeItem: () => void
+  /**
+   * The user defined properties that are passed between templates by adding attributes on the <slot /> elements.
+   * With these properties you can set values that can be read by components "living" further down the tree.
+   */
+  slotProps: TMetadataConfiguration['slotProperties']
 }
 
 export interface ItemAttributes<

--- a/packages/core/src/components/__tests__/DynamicFormItem.logic.test.ts
+++ b/packages/core/src/components/__tests__/DynamicFormItem.logic.test.ts
@@ -9,6 +9,14 @@ function getAtPath(obj: Record<string, any>, path: string): unknown {
   return path.split('.').reduce((acc, key) => acc?.[key], obj as any);
 }
 
+function findDynamicFormItemByPath(wrapper: ReturnType<typeof mount>, path: string) {
+  const item = wrapper.findAllComponents({ name: 'DynamicFormItem' })
+    .find(component => (component.vm as any).$.setupState.path === path);
+
+  expect(item).toBeDefined();
+  return item!;
+}
+
 describe('component DynamicFormItem - logic', () => {
   describe('isComplexType', () => {
     it('stores a normal field value directly at the field path', async () => {
@@ -184,6 +192,51 @@ describe('component DynamicFormItem - logic', () => {
 
       expect(getAtPath(formValues(wrapper), 'this.is.a.deep.path.value')).toBe('hello');
       expect(setupState(wrapper, 'this.is.a.deep.path')?.normalizedPath).toBe('this.is.a.deep.path.value');
+    });
+  });
+
+  describe('index', () => {
+    it('sets the index for child fields based on their position in the parent children collection', async () => {
+      const wrapper = mount(TestForm, {
+        attachTo: document.body,
+        props: {
+          metadata: [{
+            name: 'person',
+            type: 'heading',
+            children: [
+              { name: 'firstName', type: 'text' },
+              { name: 'lastName', type: 'text' },
+            ],
+          }],
+        },
+      });
+      await flushPromises();
+
+      expect(findDynamicFormItemByPath(wrapper, 'person.firstName').props('index')).toBe(0);
+      expect(findDynamicFormItemByPath(wrapper, 'person.lastName').props('index')).toBe(1);
+    });
+
+    it('sets the index for attribute fields based on their position in the parent attributes collection', async () => {
+      const wrapper = mount(TestForm, {
+        attachTo: document.body,
+        props: {
+          metadata: [{
+            name: 'text',
+            type: 'text',
+            attributes: [
+              { name: 'lang', type: 'text', minOccurs: 0 },
+              { name: 'source', type: 'text', minOccurs: 0 },
+            ],
+          }],
+        },
+      });
+      await flushPromises();
+
+      await wrapper.find('#text').setValue('hello');
+      await flushPromises();
+
+      expect(findDynamicFormItemByPath(wrapper, 'text.lang').props('index')).toBe(0);
+      expect(findDynamicFormItemByPath(wrapper, 'text.source').props('index')).toBe(1);
     });
   });
 
@@ -382,6 +435,31 @@ describe('component DynamicFormItem - logic', () => {
       await flushPromises();
 
       expect(wrapper.find('#text\\.lang').exists()).toBe(true);
+    });
+  });
+
+  describe('slotProps', () => {
+    it('forwards slot attributes added by parent templates to nested child items', async () => {
+      const wrapper = mount(TestForm, {
+        attachTo: document.body,
+        props: {
+          metadata: [{
+            name: 'person',
+            type: 'heading',
+            fieldOptions: { label: 'Person' },
+            children: [{
+              name: 'address',
+              type: 'heading',
+              fieldOptions: { label: 'Address' },
+              children: [{ name: 'street', type: 'text' }],
+            }],
+          }],
+        },
+      });
+      await flushPromises();
+
+      expect(findDynamicFormItemByPath(wrapper, 'person.address').props('slotProps')).toEqual({ level: 1 });
+      expect(findDynamicFormItemByPath(wrapper, 'person.address.street').props('slotProps')).toEqual({ level: 2 });
     });
   });
 });

--- a/packages/core/src/components/__tests__/DynamicFormItemArray.logic.test.ts
+++ b/packages/core/src/components/__tests__/DynamicFormItemArray.logic.test.ts
@@ -4,6 +4,18 @@ import { toRaw } from 'vue';
 import TestForm from '@/examples/TestForm.vue';
 import { formValues, setupState } from './DynamicFormItem.test-helpers';
 
+function addButton(wrapper: ReturnType<typeof mount>, path: string) {
+  return wrapper.find(`[data-testid="${path}-add-button"]`);
+}
+
+function findDynamicFormItemByPath(wrapper: ReturnType<typeof mount>, path: string) {
+  const item = wrapper.findAllComponents({ name: 'DynamicFormItem' })
+    .find(component => (component.vm as any).$.setupState.path === path);
+
+  expect(item).toBeDefined();
+  return item!;
+}
+
 describe('component DynamicFormItemArray - logic', () => {
   describe('isComplexType', () => {
     it('stores each array occurrence under the complexType value property when the field has attributes', async () => {
@@ -87,6 +99,29 @@ describe('component DynamicFormItemArray - logic', () => {
       await flushPromises();
 
       expect(setupState(wrapper, 'contacts[0]')?.normalizedPath).toBe('contacts[0].content');
+    });
+  });
+
+  describe('index', () => {
+    it('sets the index for each rendered array occurrence', async () => {
+      const wrapper = mount(TestForm, {
+        attachTo: document.body,
+        props: {
+          metadata: [{
+            name: 'items',
+            type: 'text',
+            fieldOptions: { label: 'Items' },
+            maxOccurs: 3,
+          }],
+        },
+      });
+      await flushPromises();
+
+      await addButton(wrapper, 'items').trigger('click');
+      await flushPromises();
+
+      expect(findDynamicFormItemByPath(wrapper, 'items[0]').props('index')).toBe(0);
+      expect(findDynamicFormItemByPath(wrapper, 'items[1]').props('index')).toBe(1);
     });
   });
 
@@ -296,6 +331,25 @@ describe('component DynamicFormItemArray - logic', () => {
       expect(person?.lastName).toBe('Doe');
       expect(person?.phones).toEqual(['+31 123 456 789']);
       expect(person?.address).toBe('Main Street 1');
+    });
+  });
+
+  describe('slotProps', () => {
+    it('forwards slot attributes added by the array template to each rendered occurrence', async () => {
+      const wrapper = mount(TestForm, {
+        attachTo: document.body,
+        props: {
+          metadata: [{
+            name: 'items',
+            type: 'text',
+            fieldOptions: { label: 'Items' },
+            maxOccurs: 3,
+          }],
+        },
+      });
+      await flushPromises();
+
+      expect(findDynamicFormItemByPath(wrapper, 'items[0]').props('slotProps')).toEqual({ hideLabel: true });
     });
   });
 });

--- a/packages/core/src/components/__tests__/DynamicFormItemChoice.logic.test.ts
+++ b/packages/core/src/components/__tests__/DynamicFormItemChoice.logic.test.ts
@@ -10,6 +10,22 @@ function removeButton(wrapper: ReturnType<typeof mount>, path: string) {
   return wrapper.find(`[data-testid="${path}-remove-button"]:not(.invisible)`);
 }
 
+function findDynamicFormItemByPath(wrapper: ReturnType<typeof mount>, path: string) {
+  const item = wrapper.findAllComponents({ name: 'DynamicFormItem' })
+    .find(component => (component.vm as any).$.setupState.path === path);
+
+  expect(item).toBeDefined();
+  return item!;
+}
+
+function findDynamicFormItemArrayByPath(wrapper: ReturnType<typeof mount>, path: string) {
+  const item = wrapper.findAllComponents({ name: 'DynamicFormItemArray' })
+    .find(component => (component.vm as any).$.setupState.path === path);
+
+  expect(item).toBeDefined();
+  return item!;
+}
+
 describe('component DynamicFormItemChoice - logic', () => {
   // ─────────────────────────────────────────────────────────────────────────
   // 1. Simple choice — two text inputs (minOccurs=1 default, maxOccurs=1 default)
@@ -215,6 +231,58 @@ describe('component DynamicFormItemChoice - logic', () => {
       expect(wrapper.findAll('input')).toHaveLength(2);
       expect(addButton(wrapper, 'pick.opt1').exists()).toBe(true);
       expect(addButton(wrapper, 'pick.opt1').exists()).toBe(true);
+    });
+  });
+
+  describe('index', () => {
+    it('sets the index for each choice child based on its position in the choice collection', async () => {
+      const wrapper = mount(TestForm, {
+        attachTo: document.body,
+        props: {
+          metadata: [{
+            name: 'pick',
+            fieldOptions: { label: 'Pick One' },
+            choice: [
+              { name: 'opt1', fieldOptions: { label: 'Option 1' } },
+              { name: 'opt2', fieldOptions: { label: 'Option 2' } },
+            ],
+          }],
+        },
+      });
+      await flushPromises();
+
+      expect(findDynamicFormItemByPath(wrapper, 'pick.opt1').props('index')).toBe(0);
+      expect(findDynamicFormItemByPath(wrapper, 'pick.opt2').props('index')).toBe(1);
+    });
+
+    it('forwards the choice child index to array children', async () => {
+      const wrapper = mount(TestForm, {
+        attachTo: document.body,
+        props: {
+          metadata: [{
+            name: 'pick',
+            fieldOptions: { label: 'Pick' },
+            choice: [
+              {
+                name: 'items',
+                type: 'text',
+                fieldOptions: { label: 'Items' },
+                maxOccurs: 2,
+              },
+              {
+                name: 'codes',
+                type: 'text',
+                fieldOptions: { label: 'Codes' },
+                maxOccurs: 2,
+              },
+            ],
+          }],
+        },
+      });
+      await flushPromises();
+
+      expect(findDynamicFormItemArrayByPath(wrapper, 'pick.items').props('index')).toBe(0);
+      expect(findDynamicFormItemArrayByPath(wrapper, 'pick.codes').props('index')).toBe(1);
     });
   });
 
@@ -507,6 +575,32 @@ describe('component DynamicFormItemChoice - logic', () => {
       expect(wrapper.find('[id="outer.group1.innerA.a1"]').attributes('disabled')).toBeDefined();
       expect(wrapper.find('[id="outer.group1.innerA.a2"]').attributes('disabled')).toBeDefined();
       expect(wrapper.find('[id="outer.group2[0].innerB.b2"]').attributes('disabled')).toBeDefined();
+    });
+  });
+
+  describe('slotProps', () => {
+    it('forwards slot attributes added by the choice template to nested array children', async () => {
+      const wrapper = mount(TestForm, {
+        attachTo: document.body,
+        props: {
+          metadata: [{
+            name: 'pick',
+            fieldOptions: { label: 'Pick' },
+            choice: [{
+              name: 'items',
+              type: 'text',
+              fieldOptions: { label: 'Items' },
+              maxOccurs: 2,
+            }],
+          }],
+        },
+      });
+      await flushPromises();
+
+      expect(findDynamicFormItemArrayByPath(wrapper, 'pick.items').props('slotProps')).toEqual({
+        belowChoiceField: true,
+        level: 1,
+      });
     });
   });
 });

--- a/packages/core/src/core/defineMetadata.ts
+++ b/packages/core/src/core/defineMetadata.ts
@@ -28,6 +28,7 @@
 export function defineMetadata<
   const FieldValueTypes extends Record<string, any>,
   ExtendedFieldProperties extends object = object,
+  SlotProperties extends object = object,
 >() {
   // Reserved field identifiers that cannot be defined by the user
   type ExcludedFields = 'input' | 'children' | 'choice' | 'array';
@@ -45,6 +46,7 @@ export function defineMetadata<
   return {
     fieldTypes: Object.keys({} as FieldValueTypes) as unknown as readonly FieldTypeMetadata[],
     extendedProperties: {} as ExtendedFieldProperties,
+    slotProperties: {} as SlotProperties,
     valueTypes: {} as ValueTypeMap,
   };
 }

--- a/packages/core/src/examples/TestFormTemplate.vue
+++ b/packages/core/src/examples/TestFormTemplate.vue
@@ -6,22 +6,6 @@ import IconButton from './components/IconButton.vue';
 
 export type Metadata = GetMetadataType<typeof metadata>;
 
-export interface Props {
-  /**
-   * Free to decide what attributes you want to pass internally between your templates.
-   * You can add any attribute to a <slot /> and then it will be accessible in props.slotProps.
-   */
-  slotProps?: {
-    hideLabel?: boolean
-    /** Example on how to keep track of the levels */
-    level?: number
-    /** Helps identifying that we're below a choice field, so if we're rendering an array we can adjust our layout */
-    belowChoiceField?: boolean
-  }
-}
-
-defineProps<Props>();
-
 const metadata = defineMetadata<
   {
     text: string
@@ -37,13 +21,24 @@ const metadata = defineMetadata<
     options?: { key: string, value: string }[]
     fullWidth?: boolean
     disabled?: boolean
+  },
+  /**
+   * Free to decide what attributes you want to pass internally between your templates.
+   * You can add any attribute to a <slot /> and then it will be accessible in props.slotProps.
+   */
+  {
+    hideLabel?: boolean
+    /** Example on how to keep track of the levels */
+    level?: number
+    /** Helps identifying that we're below a choice field, so if we're rendering an array we can adjust our layout */
+    belowChoiceField?: boolean
   }
 >();
 </script>
 
 <template>
   <DynamicFormTemplate :metadata-configuration="metadata">
-    <template #heading="{ fieldMetadata, fieldContext: { errorMessage, label }, disabled, canAddItems, addItem, canRemoveItems, removeItem }">
+    <template #heading="{ fieldMetadata, fieldContext: { errorMessage, label }, disabled, canAddItems, addItem, canRemoveItems, removeItem, slotProps }">
       <div class="mt-4" :class="{ 'md:col-span-2': fieldMetadata.fullWidth }">
         <h3 v-if="label" class="flex text-xl font-bold gap-2 items-center mb-2" :class="{ 'text-gray-500': fieldMetadata.disabled || disabled }">
           {{ label }}
@@ -62,7 +57,7 @@ const metadata = defineMetadata<
       </div>
     </template>
 
-    <template #choice="{ fieldMetadata, fieldContext: { errorMessage, label }, disabled, required }">
+    <template #choice="{ fieldMetadata, fieldContext: { errorMessage, label }, disabled, required, slotProps }">
       <div class="flex flex-col gap-2" :class="{ 'md:col-span-2': fieldMetadata.fullWidth }">
         <span class="flex gap-2 items-center" :class="{ 'text-gray-500': disabled, 'after:content-[\'*\'] after:-ml-0.5 after:text-red-500': required }">
           {{ label }}
@@ -79,7 +74,7 @@ const metadata = defineMetadata<
       </div>
     </template>
 
-    <template #array="{ fieldMetadata, fieldContext: { errorMessage, label }, disabled, required, canAddItems, addItem }">
+    <template #array="{ fieldMetadata, fieldContext: { errorMessage, label }, disabled, required, canAddItems, addItem, slotProps }">
       <!-- In case we're below a choice field, the first array item is not automatically added, so show a label with buttons -->
       <div v-if="slotProps?.belowChoiceField" :class="{ 'md:col-span-2': fieldMetadata.fullWidth }">
         <span class="flex gap-2 items-center mb-2" :class="{ 'text-gray-500': fieldMetadata.disabled || disabled }">
@@ -116,7 +111,7 @@ const metadata = defineMetadata<
       </div>
     </template>
 
-    <template #default="{ fieldMetadata, fieldContext: { errorMessage, label }, disabled, required, canAddItems, canRemoveItems, addItem, removeItem }">
+    <template #default="{ fieldMetadata, fieldContext: { errorMessage, label }, disabled, required, canAddItems, canRemoveItems, addItem, removeItem, slotProps }">
       <!-- In case we have multiple children, this is a grouped field and we adjust how it is displayed -->
       <div v-if="fieldMetadata.children?.length" :class="{ 'md:col-span-2': fieldMetadata.fullWidth }">
         <span v-if="!slotProps?.hideLabel" class="flex gap-2 items-center mb-2" :class="{ 'text-gray-500': fieldMetadata.disabled || disabled }">

--- a/packages/core/src/types/FieldMetadata.ts
+++ b/packages/core/src/types/FieldMetadata.ts
@@ -198,3 +198,15 @@ export type ComputedPropsType<T> = Omit<
       name: string
       path: string
     }>;
+
+export type TemplatePropsType<T> = Omit<
+      T,
+      | 'name' // At this point name will always be present, so remove it as being optional
+      | 'path'
+      | 'children'
+> & Readonly<{
+  // Add the name & path back as not optional and Readonly
+  name: string
+  path: string
+  children: TemplatePropsType<T>[]
+}>;

--- a/packages/core/src/types/MetadataConfiguration.ts
+++ b/packages/core/src/types/MetadataConfiguration.ts
@@ -1,5 +1,6 @@
 export interface MetadataConfiguration {
   fieldTypes: readonly string[]
   extendedProperties: object
+  slotProperties: object
   valueTypes: Record<string, any>
 }


### PR DESCRIPTION
…ndex

- Previously slotProps was defined as a separate Vue prop on the template component, requiring consumers to maintain their own Props interface. This moves it into the third generic of defineMetadata(), exposing it as a typed slotProperties field on MetadataConfiguration and surfacing it through the Attributes slot prop — keeping the API consistent with how extendedProperties works.
- Filled the index with correct value