### PR TITLE
feat: expose childFields in computedProps for reactive parent logic

### DIFF
--- a/docs/guide/dynamic-fields.md
+++ b/docs/guide/dynamic-fields.md
@@ -10,15 +10,16 @@
   type: 'text',
   fieldOptions: { label: 'Discount code' },
   computedProps: [
-    (field, value) => {
-      // field  — mutable copy of this field's metadata
-      // value  — Ref<T> pointing to this field's current value
+    (field, value, childFields) => {
+      // field       — mutable copy of this field's metadata
+      // value       — Ref<T> pointing to this field's current value
+      // childFields — Ref<FieldMetadata[]> of direct children's latest computed fields
     }
   ]
 }
 ```
 
-Write to `field` to change properties. Read from `value` to subscribe to the field's own value. Both trigger the computed to re-run whenever their reactive dependencies change.
+Write to `field` to change properties. Read from `value` to subscribe to the field's own value. Read from `childFields` to subscribe to changes in children's computed state. All three trigger the computed to re-run whenever their reactive dependencies change.
 
 ## Showing and Hiding a Field
 
@@ -109,6 +110,78 @@ By default, `computedProps` does not re-run when a child field changes. Enable t
 }
 ```
 
+## Reacting to Children's Computed Field State
+
+The `childFields` parameter gives a parent field a reactive window into its direct children's latest computed metadata — their `hidden`, `disabled`, `type`, extended properties, and so on. Reading `childFields.value` inside a function subscribes the parent to any meaningful change in a child's computed state.
+
+This is distinct from `computeOnChildValueChange`, which reacts to a child's **form value** changing. `childFields` reacts to changes in a child's **computed metadata**, such as a sibling becoming hidden or disabled through its own `computedProps`.
+
+A common use case is hiding a group when every one of its children is already hidden:
+
+```ts
+{
+  name: 'addressGroup',
+  type: 'heading',
+  computedProps: [
+    (field, _value, childFields) => {
+      if (childFields.value.length > 0 && childFields.value.every(c => c.hidden))
+        field.hidden = true;
+    }
+  ],
+  children: [
+    {
+      name: 'street',
+      type: 'text',
+      minOccurs: 0,
+      computedProps: [(f, v) => { if (!v.value) f.hidden = true; }],
+    },
+    {
+      name: 'city',
+      type: 'text',
+      minOccurs: 0,
+      computedProps: [(f, v) => { if (!v.value) f.hidden = true; }],
+    },
+  ],
+}
+```
+
+The parent re-computes only when a child's mutable properties actually change, keeping reactivity efficient.
+
+### childFields in Array Fields
+
+For array fields, `childFields.value` contains the computed fields of the rendered **occurrences** (`people[0]`, `people[1]`, …), not the child fields inside them. For changes to propagate from a grandchild all the way to the outer array field, each intermediate level must also read `childFields.value` so it re-emits when its own computed state changes.
+
+Use `field.path` to distinguish the outer array field from its occurrences — they share the same `computedProps` definition:
+
+```ts
+{
+  name: 'people',
+  type: 'heading',
+  maxOccurs: 3,
+  computedProps: [
+    // Runs for each occurrence: disable it when any of its children are disabled
+    (f, _v, childFields) => {
+      if (f.path !== 'people' && childFields.value.some(c => c.disabled))
+        f.disabled = true;
+    },
+    // Runs for the outer array field: react to each occurrence's computed state
+    (f, _v, childFields) => {
+      if (f.path === 'people') {
+        const disabledCount = childFields.value.filter(c => c.disabled).length;
+        if (disabledCount)
+          f.description = disabledCount > 0
+            ? `${disabledCount} occurrence(s) are currently disabled`
+            : undefined;
+      }
+    },
+  ],
+  children: [
+    { name: 'firstName', type: 'text' },
+    { name: 'lastName',  type: 'text' },
+  ],
+}
+```
+
 ## Multiple Functions in computedProps
 
 You can split concerns across multiple functions. They run in order, each receiving the already-mutated `field` from the previous step:
@@ -140,11 +213,12 @@ computedProps: [
 
 | Property | Reason |
 |----------|---------|
-| `name`, `path` | Always present and consistent — use for reference only |
+| `name`, `path`, `parent` | Always present and consistent — use for reference only |
 | `children`, `choice`, `attributes` | Structural; changing them mid-render is not supported |
 | `fieldOptions` | vee-validate doesn't react to these changes |
 | `maxOccurs` | Changing array length mid-render is not supported |
 | `computedProps` | Cannot be changed recursively |
+| `isComplexType`, `computeOnChildValueChange` | Not read reactively after setup; changing them has no effect |
 
 ## Dynamic Labels
 

--- a/docs/reference/field-metadata.md
+++ b/docs/reference/field-metadata.md
@@ -232,7 +232,7 @@ The sub-property name can be changed via `DynamicFormSettings.complexTypeValuePr
 
 ### `computedProps`
 
-Type: `((field: ComputedPropsType<FieldMetadata>, value: Ref<unknown>) => void)[]`
+Type: `((field: ComputedPropsType<FieldMetadata>, value: Ref<unknown>, childFields: Ref<FieldMetadata[]>) => void)[]`
 
 An array of functions that run inside a Vue `computed()` in the field's component. Use them to change field properties in response to other reactive values.
 
@@ -241,7 +241,10 @@ An array of functions that run inside a Vue `computed()` in the field's componen
   name: 'city',
   type: 'select',
   computedProps: [
-    (field) => {
+    (field, value, childFields) => {
+      // field       — writable clone of this field's metadata
+      // value       — Ref to this field's current form value
+      // childFields — Ref<FieldMetadata[]> of direct children's latest computed fields
       const country = useFieldValue('country');
       field.options = country.value === 'nl'
         ? [{ key: 'ams', value: 'Amsterdam' }]
@@ -251,9 +254,11 @@ An array of functions that run inside a Vue `computed()` in the field's componen
 }
 ```
 
-The `field` argument is a writable clone of the metadata. The `value` argument is a `Ref` to this field's current form value — read it to subscribe to changes.
+- **`field`** — writable clone of this field's metadata. Write here to change properties reactively.
+- **`value`** — `Ref` to this field's current form value. Read it to subscribe to this field's own value changes.
+- **`childFields`** — `Ref<FieldMetadata[]>` containing the latest computed field of each direct child. Read it to subscribe to changes in children's computed state (e.g. a child becoming `hidden` or `disabled`). For array fields the entries are the computed fields of each rendered occurrence.
 
-**Read-only in `computedProps`:** `name`, `path`, `children`, `choice`, `attributes`, `fieldOptions`, `maxOccurs`, `computedProps`.
+**Read-only in `computedProps`:** `name`, `path`, `parent`, `children`, `choice`, `attributes`, `fieldOptions`, `maxOccurs`, `computedProps`.
 
 See the [Dynamic Fields guide](/guide/dynamic-fields) for full examples.
 
@@ -261,7 +266,9 @@ See the [Dynamic Fields guide](/guide/dynamic-fields) for full examples.
 
 Type: `boolean` | Default: `false`
 
-When `true`, `computedProps` re-runs whenever any child field's value changes. By default, only direct reactive reads inside `computedProps` trigger re-evaluation.
+When `true`, `computedProps` re-runs whenever any child field's **form value** changes. By default, only direct reactive reads inside `computedProps` trigger re-evaluation.
+
+To react to changes in a child's **computed metadata** (e.g. becoming `hidden` or `disabled`) use the `childFields` parameter of `computedProps` instead — no flag needed.
 
 ```ts
 {
@@ -270,7 +277,7 @@ When `true`, `computedProps` re-runs whenever any child field's value changes. B
   children: [...],
   computedProps: [
     (field) => {
-      // re-runs when any child in 'address' changes
+      // re-runs when any child in 'address' changes its form value
     }
   ]
 }

--- a/packages/core/src/components/DynamicFormItem.vue
+++ b/packages/core/src/components/DynamicFormItem.vue
@@ -11,12 +11,13 @@ import type { DynamicFormSettings } from '@/types/DynamicFormSettings';
 import type { ComputedPropsType, FieldMetadata } from '@/types/FieldMetadata';
 import type { InternalFieldMetadata } from '@/types/InternalFieldMetadata';
 import { useField, useSubmitCount } from 'vee-validate';
-import { computed, inject, onBeforeUnmount, ref, watch, watchEffect } from 'vue';
+import { computed, inject, onBeforeUnmount, onMounted, ref, watch, watchEffect } from 'vue';
 import DynamicFormItemArray from '@/components/DynamicFormItemArray.vue';
 import DynamicFormItemChoice from '@/components/DynamicFormItemChoice.vue';
 import { dynamicFormSettingsKey } from '@/types/DynamicFormSettings';
 import { checkTreeHasValue } from '@/utils/checkTreeHasValue';
 import { createValidation } from '@/utils/createValidation';
+import { hashField } from '@/utils/hashField';
 import { normalizePath } from '@/utils/normalizePath';
 import { overridePath } from '@/utils/overridePath';
 import { splitToValidationFunctions } from '@/utils/splitValidationFunctions';
@@ -25,6 +26,7 @@ import { splitToValidationFunctions } from '@/utils/splitValidationFunctions';
 export interface Emit {
   (e: 'update:modelValue', value: unknown): void
   (e: 'blur', event?: Event | undefined, shouldValidate?: boolean | undefined): void
+  (e: 'update:computedField', field: InternalFieldMetadata<FieldMetadata>): void
 }
 type Props = DynamicFormItemProps<InternalMetadata>;
 // #endregion
@@ -156,12 +158,22 @@ const isChoice = computed(() => !!field.value?.choice?.length);
 const isInput = computed(() => !isArray.value && !isChoice.value && !isParent.value);
 
 // --- Reactive field and dynamic state ---
-
-// When a child updates its value, vee-validate's useFieldValue() does not re-trigger on the parent
-// computed. Incrementing this ref from notifyValueUpdate() forces computedField to re-evaluate
-// when computeOnChildValueChange is enabled.
-const childValueReactivity = ref(0);
 const initialUpdate = ref(true);
+
+/**
+ * In case of an object, the useFieldValue() in vee-validate doesn't react on an update of a value of its children.
+ * Therefore we keep track of an reactive value, that is updated by the children. That re-triggers reactivity
+ */
+const childValueReactivity = ref(0);
+
+/**
+ * Stores the latest computedField of each direct child, keyed by path.
+ * Updated when a child emits update:computedField and the hash differs from the stored one.
+ * When accessed inside a computedProps function, changes to child computed fields will
+ * reactively re-trigger the parent's computedField computation.
+ */
+const childFields = ref<Record<string, InternalFieldMetadata<FieldMetadata>>>({});
+const childFieldsArray = computed<InternalFieldMetadata<FieldMetadata>[]>(() => Object.values(childFields.value));
 
 const computedField = computed(() => {
   _analytics_fieldComputeCount++;
@@ -173,17 +185,19 @@ const computedField = computed(() => {
 
   const _computedField = (field.value?.computedProps ?? []).reduce(
     (field, compute) => {
-      // computedProps may read `value` to drive reactive transformations;
-      // if value is not accessed, it won't contribute to this computed's dependencies.
-      compute(field, value);
+      // We allow to transform the field metadata reactively based on the current value. In case the value is not
+      // called upon in any of the computedProps, it will not be part of the reactivity that triggers a re-compute.
+      // The childFieldsArray ref is passed so computedProps can subscribe to children's computed field changes.
+      compute(field, value, childFieldsArray);
       return field;
     },
-    { ...field.value, path: path.value } as ComputedPropsType<FieldMetadata>,
+    { ...field.value, path: path.value } as ComputedPropsType,
   );
 
   // Always restore our calculated path — computedProps may read it but must not override it.
   const _internalMetadata = _computedField as InternalMetadata;
   _internalMetadata.path = path.value;
+  _internalMetadata._hash = hashField(_internalMetadata);
 
   return _internalMetadata;
 });
@@ -370,6 +384,19 @@ watch(
   },
 );
 
+// Emit the initial computedField after mounting (children mount before parents, so the parent
+// template listener is already in place). Then watch for hash changes to keep the parent in sync.
+// Deferring to onMounted avoids accessing computedField during setup, which would make it a
+// synchronous dep and break the infinite-loop guard test.
+onMounted(() => {
+  emits('update:computedField', computedField.value);
+  watch(() => computedField.value._hash, (newHash, oldHash) => {
+    if (newHash === oldHash)
+      return;
+    emits('update:computedField', computedField.value);
+  });
+});
+
 onBeforeUnmount(() => {
   if (_computeLoopResetTimer != null)
     clearTimeout(_computeLoopResetTimer);
@@ -391,6 +418,22 @@ onBeforeUnmount(() => {
 // #endregion
 
 // #region Methods
+
+/**
+ * Called when a direct child (or a DynamicFormItemArray/Choice that wraps a child) emits update:computedField.
+ * Only updates childFields when the child's hash has changed, so the parent's computedProps
+ * that access childFields are only re-evaluated when something meaningful changed.
+ * When childFields is updated, the parent's own computedField may re-run (if it accesses childFields),
+ * and the watch above will emit update:computedField upward, notifying the entire ancestor chain.
+ */
+function onChildComputedFieldUpdate(field: InternalFieldMetadata<FieldMetadata>) {
+  if (!field.path)
+    return;
+  const existing = childFields.value[field.path];
+  if (existing?._hash === field._hash)
+    return;
+  childFields.value[field.path] = field;
+}
 
 function notifyValueUpdate() {
   _analytics_notifyValueUpdateCount++;
@@ -420,6 +463,7 @@ function updateArrayValue(_value: unknown) {
       :field-metadata="computedField"
 
       @update:model-value="notifyValueUpdate"
+      @update:computed-field="onChildComputedFieldUpdate"
     />
   </template>
   <template v-else-if="isArray">
@@ -429,6 +473,7 @@ function updateArrayValue(_value: unknown) {
       :field-metadata="computedField"
 
       @update:model-value="updateArrayValue"
+      @update:computed-field="onChildComputedFieldUpdate"
     />
   </template>
   <template v-else>
@@ -460,6 +505,7 @@ function updateArrayValue(_value: unknown) {
             :max-occurs-override="_maxOccursOverride"
 
             @update:model-value="notifyValueUpdate"
+            @update:computed-field="onChildComputedFieldUpdate"
           />
         </template>
         <template v-if="!isParent">
@@ -492,6 +538,7 @@ function updateArrayValue(_value: unknown) {
           :max-occurs-override="_maxOccursOverride"
 
           @update:model-value="notifyValueUpdate"
+          @update:computed-field="onChildComputedFieldUpdate"
         />
       </template>
     </component>

--- a/packages/core/src/components/DynamicFormItemArray.vue
+++ b/packages/core/src/components/DynamicFormItemArray.vue
@@ -23,6 +23,7 @@ import { splitToValidationFunctions } from '@/utils/splitValidationFunctions';
 // #region Interfaces
 export interface Emit {
   (e: 'update:modelValue', value: unknown): void
+  (e: 'update:computedField', field: InternalFieldMetadata<FieldMetadata>): void
 }
 type Props = DynamicFormItemProps<InternalMetadata>;
 // #endregion
@@ -254,6 +255,7 @@ function guardAndNotifyItemUpdate(value: any, index: number) {
         is-array-override="single"
 
         @update:model-value="guardAndNotifyItemUpdate($event, arrayIndex)"
+        @update:computed-field="emits('update:computedField', $event)"
         @blur="handleBlur"
       />
     </template>

--- a/packages/core/src/components/DynamicFormItemChoice.vue
+++ b/packages/core/src/components/DynamicFormItemChoice.vue
@@ -21,6 +21,7 @@ import { overridePath } from '@/utils/overridePath';
 // #region Interfaces
 export interface Emit {
   (e: 'update:modelValue', value: unknown): void
+  (e: 'update:computedField', field: InternalFieldMetadata<FieldMetadata>): void
 }
 type Props = DynamicFormItemProps<InternalMetadata>;
 
@@ -235,8 +236,12 @@ watch(field, (_field) => {
   if (!_field)
     return;
 
+  // Initialize tracking entries for choice children that haven't been set up yet.
+  // We skip indices that are already present so that a metadata-reference change
+  // (e.g. from a recomputed metadataWithEdit) does not reset values that users have already entered.
   _field.choice?.forEach((child, index) => {
-    updateChildValue(undefined, index, child.maxOccurs);
+    if (!(index in childValues.value))
+      updateChildValue(undefined, index, child.maxOccurs);
   });
 }, { immediate: true });
 
@@ -317,6 +322,7 @@ function updateChildValue(
       part-of-choice-field
 
       @update:model-value="updateChildValue($event, 0, singleChild!.maxOccurs, true)"
+      @update:computed-field="emits('update:computedField', $event)"
     />
     <template v-else>
       <DynamicFormItem
@@ -333,6 +339,7 @@ function updateChildValue(
         part-of-choice-field
 
         @update:model-value="updateChildValue($event, index, child.maxOccurs)"
+        @update:computed-field="emits('update:computedField', $event)"
       />
     </template>
   </component>

--- a/packages/core/src/components/__tests__/DynamicFormItem.logic.test.ts
+++ b/packages/core/src/components/__tests__/DynamicFormItem.logic.test.ts
@@ -241,6 +241,191 @@ describe('component DynamicFormItem - logic', () => {
   });
 
   describe('computedProps', () => {
+    describe('childFields', () => {
+      it('provides direct children computed fields as the third argument', async () => {
+        let capturedPaths: string[] = [];
+        mount(TestForm, {
+          attachTo: document.body,
+          props: {
+            metadata: [{
+              name: 'parent',
+              type: 'text',
+              computedProps: [(_f, _v, childFields) => {
+                capturedPaths = childFields.value.map(c => c.path as string).filter(Boolean);
+              }],
+              children: [
+                { name: 'firstName', type: 'text' },
+                { name: 'lastName', type: 'text' },
+              ],
+            }],
+          },
+        });
+        await flushPromises();
+
+        expect(capturedPaths).toContain('parent.firstName');
+        expect(capturedPaths).toContain('parent.lastName');
+      });
+
+      it('re-computes when a child computed field hash changes', async () => {
+        let updateCount = 0;
+        let disabledChildCount = 0;
+        const wrapper = mount(TestForm, {
+          attachTo: document.body,
+          props: {
+            metadata: [{
+              name: 'parent',
+              type: 'text',
+              computedProps: [(_f, _v, childFields) => {
+                updateCount++;
+                disabledChildCount = childFields.value.filter(c => c.disabled).length;
+              }],
+              children: [{
+                name: 'child',
+                type: 'text',
+                computedProps: [(f, v) => {
+                  if (v.value)
+                    f.disabled = true;
+                }],
+              }],
+            }],
+          },
+        });
+        await flushPromises();
+
+        expect(disabledChildCount).toBe(0);
+        const countBeforeChange = updateCount;
+
+        await wrapper.find('#parent\\.child').setValue('hello');
+        await flushPromises();
+
+        expect(updateCount).toBeGreaterThan(countBeforeChange);
+        expect(disabledChildCount).toBe(1);
+      });
+
+      it('does not re-compute when the child computed field hash is unchanged', async () => {
+        let updateCount = 0;
+        const wrapper = mount(TestForm, {
+          attachTo: document.body,
+          props: {
+            metadata: [{
+              name: 'parent',
+              type: 'text',
+              computedProps: [(_f, _v, childFields) => {
+                updateCount++;
+                childFields.value.forEach(() => {}); // subscribe to childFields reactivity
+              }],
+              children: [{
+                name: 'child',
+                type: 'text',
+                computedProps: [(f, v) => {
+                  if (v.value)
+                    f.disabled = true;
+                }],
+              }],
+            }],
+          },
+        });
+        await flushPromises();
+
+        // Set 'hello' — child becomes disabled, hash changes, parent re-computes
+        await wrapper.find('#parent\\.child').setValue('hello');
+        await flushPromises();
+        const countAfterFirstChange = updateCount;
+
+        // Set 'world' — child stays disabled (same hash), parent should NOT re-compute
+        await wrapper.find('#parent\\.child').setValue('world');
+        await flushPromises();
+
+        expect(updateCount).toBe(countAfterFirstChange);
+      });
+
+      it('hides the parent when all children report as hidden via childFields', async () => {
+        const wrapper = mount(TestForm, {
+          attachTo: document.body,
+          props: {
+            metadata: [{
+              name: 'parent',
+              type: 'text',
+              computedProps: [(thisField, _v, childFields) => {
+                if (childFields.value.length > 0 && childFields.value.every(c => c.hidden))
+                  thisField.hidden = true;
+              }],
+              children: [
+                {
+                  name: 'child1',
+                  type: 'text',
+                  minOccurs: 0,
+                  computedProps: [(f) => { f.hidden = true; }],
+                },
+                {
+                  name: 'child2',
+                  type: 'text',
+                  minOccurs: 0,
+                  computedProps: [(f) => { f.hidden = true; }],
+                },
+              ],
+            }],
+          },
+        });
+        await flushPromises();
+
+        expect(setupState(wrapper, 'parent')?.computedField.hidden).toBe(true);
+      });
+      it('hides a parent group in view mode when all direct child fields have no value', async () => {
+        const wrapper = mount(TestForm, {
+          attachTo: document.body,
+          props: {
+            initialEdit: false,
+            hideFieldsWithoutValue: true,
+            metadata: [{
+              name: 'person',
+              type: 'heading',
+              fieldOptions: { label: 'Personal Info' },
+              children: [
+                { name: 'firstName', type: 'text', minOccurs: 0, fieldOptions: { label: 'First Name' } },
+                { name: 'lastName', type: 'text', minOccurs: 0, fieldOptions: { label: 'Last Name' } },
+              ],
+            }],
+          },
+        });
+        await flushPromises();
+
+        expect(wrapper.text()).not.toContain('Personal Info');
+        expect(wrapper.text()).not.toContain('First Name');
+        expect(wrapper.text()).not.toContain('Last Name');
+      });
+
+      it('keeps a parent group visible in view mode when a direct child field has a value', async () => {
+        const wrapper = mount(TestForm, {
+          attachTo: document.body,
+          props: {
+            initialEdit: false,
+            hideFieldsWithoutValue: true,
+            initialValues: {
+              person: {
+                firstName: 'Jack',
+              },
+            },
+            metadata: [{
+              name: 'person',
+              type: 'heading',
+              fieldOptions: { label: 'Personal Info' },
+              children: [
+                { name: 'firstName', type: 'text', minOccurs: 0, fieldOptions: { label: 'First Name' } },
+                { name: 'lastName', type: 'text', minOccurs: 0, fieldOptions: { label: 'Last Name' } },
+              ],
+            }],
+          },
+        });
+        await flushPromises();
+
+        expect(wrapper.text()).toContain('Personal Info');
+        expect(wrapper.text()).toContain('First Name');
+        expect(wrapper.text()).not.toContain('Last Name');
+        expect((wrapper.find('input[id="person.firstName"]').element as HTMLInputElement).value).toBe('Jack');
+      });
+    });
+
     it('re-computes when a child value changes and computeOnChildValueChange is true', async () => {
       let updatedValue: unknown = {};
       let updateCount = 0;
@@ -252,7 +437,7 @@ describe('component DynamicFormItem - logic', () => {
             type: 'text',
             fieldOptions: { label: 'Person' },
             computeOnChildValueChange: true,
-            computedProps: [(f, v) => {
+            computedProps: [(_f, v) => {
               updateCount++;
               updatedValue = v.value;
             }],
@@ -306,7 +491,7 @@ describe('component DynamicFormItem - logic', () => {
             name: 'person',
             type: 'text',
             fieldOptions: { label: 'Person' },
-            computedProps: [(f, v) => {
+            computedProps: [(_f, v) => {
               updateCount++;
               // for testing we clone, to make sure we don't have a reference to the object that gets updated
               updatedValue = structuredClone(toRaw(v.value));

--- a/packages/core/src/components/__tests__/DynamicFormItemArray.logic.test.ts
+++ b/packages/core/src/components/__tests__/DynamicFormItemArray.logic.test.ts
@@ -296,6 +296,139 @@ describe('component DynamicFormItemArray - logic', () => {
     });
   });
 
+  describe('computedProps / childFields', () => {
+    it('array occurrences are accessible in the array field childFields', async () => {
+      let capturedOccurrencePaths: string[] = [];
+      mount(TestForm, {
+        attachTo: document.body,
+        props: {
+          metadata: [{
+            name: 'items',
+            type: 'text',
+            maxOccurs: 3,
+            computedProps: [(f, _v, childFields) => {
+              // Only aggregate for the parent-level array field, not for occurrences
+              if (f.path === 'items')
+                capturedOccurrencePaths = childFields.value.map(c => c.path as string).filter(Boolean);
+            }],
+          }],
+        },
+      });
+      await flushPromises();
+
+      expect(capturedOccurrencePaths).toContain('items[0]');
+    });
+
+    it('propagates a child-field change through an occurrence up to the outer array field', async () => {
+      // Structure: people (array, maxOccurs=3, children: firstName, lastName)
+      // people[0].firstName becomes disabled → people[0] detects this via childFields and
+      // disables itself → DynamicFormItemArray forwards the event → people detects the change
+      // via its own childFields and increments disabledOccurrenceCount.
+      let disabledOccurrenceCount = 0;
+      const wrapper = mount(TestForm, {
+        attachTo: document.body,
+        props: {
+          metadata: [{
+            name: 'people',
+            type: 'heading',
+            maxOccurs: 3,
+            computedProps: [
+              // Occurrence level: disable the occurrence when any of its children are disabled
+              (f, _v, childFields) => {
+                if (f.path !== 'people' && childFields.value.some(c => c.disabled))
+                  f.disabled = true;
+              },
+              // Array level: track how many occurrences are disabled
+              (f, _v, childFields) => {
+                if (f.path === 'people') {
+                  disabledOccurrenceCount = childFields.value.filter(c => c.disabled).length;
+                  childFields.value.forEach(() => {}); // subscribe to childFields reactivity
+                }
+              },
+            ],
+            children: [
+              {
+                name: 'firstName',
+                type: 'text',
+                computedProps: [(f, v) => {
+                  if (v.value === 'disable')
+                    f.disabled = true;
+                }],
+              },
+              { name: 'lastName', type: 'text' },
+            ],
+          }],
+        },
+      });
+      await flushPromises();
+
+      expect(disabledOccurrenceCount).toBe(0);
+
+      await wrapper.find('input[id="people[0].firstName"]').setValue('disable');
+      await flushPromises();
+
+      expect(disabledOccurrenceCount).toBe(1);
+    });
+
+    it('hides a parent group in view mode when its direct array child has no value', async () => {
+      const wrapper = mount(TestForm, {
+        attachTo: document.body,
+        props: {
+          initialEdit: false,
+          hideFieldsWithoutValue: true,
+          metadata: [{
+            name: 'contact',
+            type: 'heading',
+            fieldOptions: { label: 'Contact' },
+            children: [{
+              name: 'emails',
+              type: 'text',
+              maxOccurs: 3,
+              minOccurs: 0,
+              fieldOptions: { label: 'Emails' },
+            }],
+          }],
+        },
+      });
+      await flushPromises();
+
+      expect(wrapper.text()).not.toContain('Contact');
+      expect(wrapper.text()).not.toContain('Emails');
+    });
+
+    it('keeps a parent group visible in view mode when its direct array child has a value', async () => {
+      const wrapper = mount(TestForm, {
+        attachTo: document.body,
+        props: {
+          initialEdit: false,
+          hideFieldsWithoutValue: true,
+          initialValues: {
+            contact: {
+              emails: ['john@example.com'],
+            },
+          },
+          metadata: [{
+            name: 'contact',
+            type: 'heading',
+            fieldOptions: { label: 'Contact' },
+            children: [{
+              name: 'emails',
+              type: 'text',
+              maxOccurs: 3,
+              minOccurs: 0,
+              fieldOptions: { label: 'Emails' },
+            }],
+          }],
+        },
+      });
+      await flushPromises();
+
+      expect(wrapper.text()).toContain('Contact');
+      expect(wrapper.text()).toContain('Emails');
+      expect((wrapper.find('input[id="contact.emails[0]"]').element as HTMLInputElement).value).toBe('john@example.com');
+    });
+  });
+
   describe('nested metadata', () => {
     it('supports array occurrences that mix child arrays with normal fields', async () => {
       const wrapper = mount(TestForm, {

--- a/packages/core/src/components/__tests__/DynamicFormItemChoice.logic.test.ts
+++ b/packages/core/src/components/__tests__/DynamicFormItemChoice.logic.test.ts
@@ -1,6 +1,7 @@
 import { flushPromises, mount } from '@vue/test-utils';
 import { describe, expect, it } from 'vitest';
 import TestForm from '@/examples/TestForm.vue';
+import { formValues } from './DynamicFormItem.test-helpers';
 
 function addButton(wrapper: ReturnType<typeof mount>, path: string) {
   return wrapper.find(`[data-testid="${path}-add-button"]`);
@@ -84,6 +85,37 @@ describe('component DynamicFormItemChoice - logic', () => {
       await flushPromises();
 
       expect(wrapper.find('[id="pick.opt2"]').attributes('disabled')).toBeUndefined();
+    });
+
+    it('preserves the active child state when the metadata reference changes', async () => {
+      const metadata = [{
+        name: 'pick',
+        fieldOptions: { label: 'Pick One' },
+        choice: [
+          { name: 'opt1', fieldOptions: { label: 'Option 1' } },
+          { name: 'opt2', fieldOptions: { label: 'Option 2' } },
+        ],
+      }];
+      const wrapper = mount(TestForm, {
+        attachTo: document.body,
+        props: { metadata },
+      });
+      await flushPromises();
+
+      await wrapper.find('[id="pick.opt1"]').setValue('hello');
+      await flushPromises();
+
+      expect(wrapper.find('[id="pick.opt2"]').attributes('disabled')).toBeDefined();
+      expect(formValues(wrapper).pick?.opt1).toBe('hello');
+
+      await wrapper.setProps({
+        metadata: structuredClone(metadata),
+      });
+      await flushPromises();
+
+      expect((wrapper.find('[id="pick.opt1"]').element as HTMLInputElement).value).toBe('hello');
+      expect(wrapper.find('[id="pick.opt2"]').attributes('disabled')).toBeDefined();
+      expect(formValues(wrapper).pick?.opt1).toBe('hello');
     });
   });
 
@@ -462,7 +494,139 @@ describe('component DynamicFormItemChoice - logic', () => {
   });
 
   // ─────────────────────────────────────────────────────────────────────────
-  // 7. Multi-layer — outer choice with group children that contain inner choices
+  // 7. computedProps / childFields — choice options accessible to parent
+  // ─────────────────────────────────────────────────────────────────────────
+  describe('computedProps / childFields', () => {
+    it('choice options are accessible in the parent field childFields', async () => {
+      let capturedPaths: string[] = [];
+      mount(TestForm, {
+        attachTo: document.body,
+        props: {
+          metadata: [{
+            name: 'pick',
+            fieldOptions: { label: 'Pick One' },
+            computedProps: [(_f, _v, childFields) => {
+              capturedPaths = childFields.value.map(c => c.path as string).filter(Boolean);
+            }],
+            choice: [
+              { name: 'opt1', fieldOptions: { label: 'Option 1' } },
+              { name: 'opt2', fieldOptions: { label: 'Option 2' } },
+            ],
+          }],
+        },
+      });
+      await flushPromises();
+
+      expect(capturedPaths).toContain('pick.opt1');
+      expect(capturedPaths).toContain('pick.opt2');
+    });
+
+    it('re-computes when a choice option computed field changes', async () => {
+      let updateCount = 0;
+      let hiddenChildCount = 0;
+      const wrapper = mount(TestForm, {
+        attachTo: document.body,
+        props: {
+          metadata: [{
+            name: 'pick',
+            fieldOptions: { label: 'Pick One' },
+            computedProps: [(_f, _v, childFields) => {
+              updateCount++;
+              hiddenChildCount = childFields.value.filter(c => c.hidden).length;
+            }],
+            choice: [
+              {
+                name: 'opt1',
+                fieldOptions: { label: 'Option 1' },
+                computedProps: [(f, v) => {
+                  if (v.value === 'hide-me')
+                    f.hidden = true;
+                }],
+              },
+              { name: 'opt2', fieldOptions: { label: 'Option 2' } },
+            ],
+          }],
+        },
+      });
+      await flushPromises();
+
+      expect(hiddenChildCount).toBe(0);
+      const countBeforeChange = updateCount;
+
+      await wrapper.find('[id="pick.opt1"]').setValue('hide-me');
+      await flushPromises();
+
+      expect(updateCount).toBeGreaterThan(countBeforeChange);
+      expect(hiddenChildCount).toBe(1);
+    });
+
+    it('hides a parent group in view mode when its direct choice child has no value', async () => {
+      const wrapper = mount(TestForm, {
+        attachTo: document.body,
+        props: {
+          initialEdit: false,
+          hideFieldsWithoutValue: true,
+          metadata: [{
+            name: 'contact',
+            type: 'heading',
+            fieldOptions: { label: 'Contact' },
+            children: [{
+              name: 'preferred',
+              minOccurs: 0,
+              fieldOptions: { label: 'Preferred Contact' },
+              choice: [
+                { name: 'email', fieldOptions: { label: 'Email' }, minOccurs: 0 },
+                { name: 'phone', fieldOptions: { label: 'Phone' }, minOccurs: 0 },
+              ],
+            }],
+          }],
+        },
+      });
+      await flushPromises();
+
+      expect(wrapper.text()).not.toContain('Contact');
+      expect(wrapper.text()).not.toContain('Preferred Contact');
+    });
+
+    it('keeps a parent group visible in view mode when its direct choice child has a value', async () => {
+      const wrapper = mount(TestForm, {
+        attachTo: document.body,
+        props: {
+          initialEdit: false,
+          hideFieldsWithoutValue: true,
+          initialValues: {
+            contact: {
+              preferred: {
+                email: 'john@example.com',
+              },
+            },
+          },
+          metadata: [{
+            name: 'contact',
+            type: 'heading',
+            fieldOptions: { label: 'Contact' },
+            children: [{
+              name: 'preferred',
+              minOccurs: 0,
+              fieldOptions: { label: 'Preferred Contact' },
+              choice: [
+                { name: 'email', fieldOptions: { label: 'Email' }, minOccurs: 0 },
+                { name: 'phone', fieldOptions: { label: 'Phone' }, minOccurs: 0 },
+              ],
+            }],
+          }],
+        },
+      });
+      await flushPromises();
+
+      expect(wrapper.text()).toContain('Contact');
+      expect(wrapper.text()).toContain('Preferred Contact');
+      expect((wrapper.find('[id="contact.preferred.email"]').element as HTMLInputElement).value).toBe('john@example.com');
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // 8. Multi-layer — outer choice with group children that contain inner choices
   // ─────────────────────────────────────────────────────────────────────────
   describe('multi-layer — group children each containing an inner choice field and arrays', () => {
     function mountMultiLayerChoice() {

--- a/packages/core/src/examples/TestForm.vue
+++ b/packages/core/src/examples/TestForm.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
-import type { Metadata } from './TestFormTemplate.vue';
+import type { GenericObject } from 'vee-validate';
 
+import type { Metadata } from './TestFormTemplate.vue';
 import type { DynamicFormSettings } from '@/types/DynamicFormSettings';
 import { computed, ref } from 'vue';
+import { checkTreeHasValue } from '@/utils/checkTreeHasValue';
+import { mapEachMetadataItem } from '@/utils/mapEachMetadataItem';
 import DynamicForm from '../components/DynamicForm.vue';
 import { useDynamicForm } from '../core/useDynamicForm';
 import TestFormTemplate from './TestFormTemplate.vue';
@@ -11,23 +14,44 @@ export interface Props {
   metadata: Metadata[]
   settings?: DynamicFormSettings
   showDebugState?: boolean
+  initialEdit?: boolean
+  hideFieldsWithoutValue?: boolean
+  initialValues?: GenericObject
 }
 
-const { metadata, settings: _settings, showDebugState = false } = defineProps<Props>();
+const { metadata, settings: _settings, initialEdit = true, hideFieldsWithoutValue = false, showDebugState = false, initialValues } = defineProps<Props>();
 
-const { values, handleSubmit, errors, meta } = useDynamicForm();
+const { values, handleSubmit, errors, meta } = useDynamicForm({
+  initialValues,
+});
 const manualValues = ref();
-const editMode = ref(true);
+const editMode = ref(initialEdit);
 const isSubmitted = ref(false);
 
 // Add edit mode functionality to the form. In case we're not in edit mode, disable all items.
 const metadataWithEdit = computed(() => metadata?.map(x => mapEachMetadataItem(x, (item) => {
   item.computedProps = item.computedProps ?? [];
-  item.computedProps?.push((thisField) => {
-    // Re-compute the disabled property of each field, when editMode changes
+
+  // Disable all fields when not in edit mode
+  item.computedProps.push((thisField) => {
     if (!editMode.value)
       thisField.disabled = true;
   });
+
+  if (hideFieldsWithoutValue) {
+  // In view mode, hide fields that have no value
+    item.computedProps.push((thisField, fieldValue) => {
+      if (!editMode.value && !checkTreeHasValue(fieldValue.value))
+        thisField.hidden = true;
+    });
+
+    // In view mode, hide a parent field when all of its children are hidden
+    item.computedProps.push((thisField, _fieldValue, childFields) => {
+      if (!editMode.value && childFields.value.length > 0 && childFields.value.every(c => c.hidden))
+        thisField.hidden = true;
+    });
+  }
+
   return item;
 })));
 
@@ -57,26 +81,17 @@ function submit(e?: Event) {
   handleSubmit(
     (_values) => {
       isSubmitted.value = true;
+      editMode.value = false;
     },
     ({ errors: _errors }) => {
       isSubmitted.value = false;
     },
   )(e);
 };
-
-function mapEachMetadataItem(metadata: Metadata, callbackFunc: (item: Metadata) => Metadata) {
-  if (!metadata || !callbackFunc)
-    return metadata;
-
-  metadata = callbackFunc?.({ ...metadata });
-  metadata.children = metadata?.children?.map(x => mapEachMetadataItem(x, callbackFunc));
-  metadata.choice = metadata?.choice?.map(x => mapEachMetadataItem(x, callbackFunc));
-  return metadata;
-}
 </script>
 
 <template>
-  <form @submit="submit">
+  <form @submit.prevent="submit">
     <div class="flex justify-end gap-2">
       <button v-if="!editMode" type="button" class="cursor-pointer mt-4 bg-blue-500 text-white px-4 py-2 rounded" data-testid="submit" @click="editMode = true">
         Edit

--- a/packages/core/src/examples/TestFormTemplate.vue
+++ b/packages/core/src/examples/TestFormTemplate.vue
@@ -21,6 +21,7 @@ const metadata = defineMetadata<
     options?: { key: string, value: string }[]
     fullWidth?: boolean
     disabled?: boolean
+    hidden?: boolean
   },
   /**
    * Free to decide what attributes you want to pass internally between your templates.
@@ -32,6 +33,7 @@ const metadata = defineMetadata<
     level?: number
     /** Helps identifying that we're below a choice field, so if we're rendering an array we can adjust our layout */
     belowChoiceField?: boolean
+    hidden?: boolean
   }
 >();
 </script>
@@ -39,7 +41,7 @@ const metadata = defineMetadata<
 <template>
   <DynamicFormTemplate :metadata-configuration="metadata">
     <template #heading="{ fieldMetadata, fieldContext: { errorMessage, label }, disabled, canAddItems, addItem, canRemoveItems, removeItem, slotProps }">
-      <div class="mt-4" :class="{ 'md:col-span-2': fieldMetadata.fullWidth }">
+      <div v-if="!fieldMetadata.hidden" class="mt-4" :class="{ 'md:col-span-2': fieldMetadata.fullWidth }">
         <h3 v-if="label" class="flex text-xl font-bold gap-2 items-center mb-2" :class="{ 'text-gray-500': fieldMetadata.disabled || disabled }">
           {{ label }}
           <IconButton v-if="canAddItems" icon="plus" tabindex="-1" :data-testid="`${fieldMetadata.path}-add-button`" @click="addItem" />
@@ -58,7 +60,7 @@ const metadata = defineMetadata<
     </template>
 
     <template #choice="{ fieldMetadata, fieldContext: { errorMessage, label }, disabled, required, slotProps }">
-      <div class="flex flex-col gap-2" :class="{ 'md:col-span-2': fieldMetadata.fullWidth }">
+      <div v-if="!fieldMetadata.hidden" class="flex flex-col gap-2" :class="{ 'md:col-span-2': fieldMetadata.fullWidth }">
         <span class="flex gap-2 items-center" :class="{ 'text-gray-500': disabled, 'after:content-[\'*\'] after:-ml-0.5 after:text-red-500': required }">
           {{ label }}
         </span>
@@ -75,8 +77,11 @@ const metadata = defineMetadata<
     </template>
 
     <template #array="{ fieldMetadata, fieldContext: { errorMessage, label }, disabled, required, canAddItems, addItem, slotProps }">
+      <template v-if="fieldMetadata.hidden">
+        <!-- Show nothing -->
+      </template>
       <!-- In case we're below a choice field, the first array item is not automatically added, so show a label with buttons -->
-      <div v-if="slotProps?.belowChoiceField" :class="{ 'md:col-span-2': fieldMetadata.fullWidth }">
+      <div v-else-if="slotProps?.belowChoiceField" :class="{ 'md:col-span-2': fieldMetadata.fullWidth }">
         <span class="flex gap-2 items-center mb-2" :class="{ 'text-gray-500': fieldMetadata.disabled || disabled }">
           {{ label }}
           <span v-if="required" class="-ml-0.5 text-red-500">*</span>
@@ -112,44 +117,46 @@ const metadata = defineMetadata<
     </template>
 
     <template #default="{ fieldMetadata, fieldContext: { errorMessage, label }, disabled, required, canAddItems, canRemoveItems, addItem, removeItem, slotProps }">
-      <!-- In case we have multiple children, this is a grouped field and we adjust how it is displayed -->
-      <div v-if="fieldMetadata.children?.length" :class="{ 'md:col-span-2': fieldMetadata.fullWidth }">
-        <span v-if="!slotProps?.hideLabel" class="flex gap-2 items-center mb-2" :class="{ 'text-gray-500': fieldMetadata.disabled || disabled }">
-          {{ label }}
-          <span v-if="required" class="-ml-0.5 text-red-500">*</span>
-          <IconButton v-if="canAddItems" icon="plus" tabindex="-1" :data-testid="`${fieldMetadata.path}-add-button`" @click="addItem" />
-          <IconButton v-if="canRemoveItems" icon="minus" tabindex="-1" :data-testid="`${fieldMetadata.path}-remove-button`" color="red" @click="removeItem" />
-        </span>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-6 ms-6">
-          <slot :level="(slotProps?.level ?? 0) + 1" />
-        </div>
-        <pre class="text-sm whitespace-pre-wrap">{{ fieldMetadata.description }}</pre>
-        <span
-          v-if="errorMessage.value"
-          class="text-red-600 text-sm"
-          :data-testid="`${fieldMetadata.path}-error-message`"
-        >{{ errorMessage.value }}</span>
-      </div>
-      <!-- Otherwise load only the slot with the input -->
-      <div v-else class="flex flex-col gap-2" :class="{ 'md:col-span-2': fieldMetadata.fullWidth }">
-        <label v-if="!slotProps?.hideLabel" :for="fieldMetadata.path" :class="{ 'text-gray-500': fieldMetadata.disabled || disabled }">
-          {{ label }}
-          <span v-if="required" class="-ml-0.5 text-red-500">*</span>
-        </label>
-        <div class="flex gap-2 items-center">
-          <div class="flex flex-col grow">
-            <slot />
+      <template v-if="!fieldMetadata.hidden">
+        <!-- In case we have multiple children, this is a grouped field and we adjust how it is displayed -->
+        <div v-if="fieldMetadata.children?.length" :class="{ 'md:col-span-2': fieldMetadata.fullWidth }">
+          <span v-if="!slotProps?.hideLabel" class="flex gap-2 items-center mb-2" :class="{ 'text-gray-500': fieldMetadata.disabled || disabled }">
+            {{ label }}
+            <span v-if="required" class="-ml-0.5 text-red-500">*</span>
+            <IconButton v-if="canAddItems" icon="plus" tabindex="-1" :data-testid="`${fieldMetadata.path}-add-button`" @click="addItem" />
+            <IconButton v-if="canRemoveItems" icon="minus" tabindex="-1" :data-testid="`${fieldMetadata.path}-remove-button`" color="red" @click="removeItem" />
+          </span>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-6 ms-6">
+            <slot :level="(slotProps?.level ?? 0) + 1" />
           </div>
-          <IconButton :class="{ invisible: !canRemoveItems }" icon="minus" tabindex="-1" color="red" :data-testid="`${fieldMetadata.path}-remove-button`" @click="removeItem" />
+          <pre class="text-sm whitespace-pre-wrap">{{ fieldMetadata.description }}</pre>
+          <span
+            v-if="errorMessage.value"
+            class="text-red-600 text-sm"
+            :data-testid="`${fieldMetadata.path}-error-message`"
+          >{{ errorMessage.value }}</span>
         </div>
-        <pre class="text-sm whitespace-pre-wrap">{{ fieldMetadata.description }}</pre>
-        <span
-          v-if="errorMessage.value"
-          class="text-red-600 text-sm"
-          :data-testid="`${fieldMetadata.path}-error-message`"
-        >{{ errorMessage.value }}</span>
-      </div>
-      <slot name="attributes" />
+        <!-- Otherwise load only the slot with the input -->
+        <div v-else class="flex flex-col gap-2" :class="{ 'md:col-span-2': fieldMetadata.fullWidth }">
+          <label v-if="!slotProps?.hideLabel" :for="fieldMetadata.path" :class="{ 'text-gray-500': fieldMetadata.disabled || disabled }">
+            {{ label }}
+            <span v-if="required" class="-ml-0.5 text-red-500">*</span>
+          </label>
+          <div class="flex gap-2 items-center">
+            <div class="flex flex-col grow">
+              <slot />
+            </div>
+            <IconButton :class="{ invisible: !canRemoveItems }" icon="minus" tabindex="-1" color="red" :data-testid="`${fieldMetadata.path}-remove-button`" @click="removeItem" />
+          </div>
+          <pre class="text-sm whitespace-pre-wrap">{{ fieldMetadata.description }}</pre>
+          <span
+            v-if="errorMessage.value"
+            class="text-red-600 text-sm"
+            :data-testid="`${fieldMetadata.path}-error-message`"
+          >{{ errorMessage.value }}</span>
+        </div>
+        <slot name="attributes" />
+      </template>
     </template>
 
     <template #select-input="{ fieldMetadata, fieldContext: { value, handleBlur, handleChange }, disabled }">

--- a/packages/core/src/examples/__tests__/TestFormTemplate.testcases.ts
+++ b/packages/core/src/examples/__tests__/TestFormTemplate.testcases.ts
@@ -1,6 +1,7 @@
+import type { GenericObject } from 'vee-validate';
 import type { Metadata } from '@/examples/TestFormTemplate.vue';
-import type { DynamicFormSettings } from '@/types/DynamicFormSettings';
 
+import type { DynamicFormSettings } from '@/types/DynamicFormSettings';
 import { defineComponent, h, markRaw } from 'vue';
 import TestForm from '@/examples/TestForm.vue';
 
@@ -94,6 +95,41 @@ export const choiceTestCase = createTestCase([
   },
 ]);
 
+export const childFieldsTestCase = createTestCase([
+  {
+    fieldOptions: { label: 'Personal Info' },
+    type: 'heading',
+    name: 'person',
+    description: 'Only showing the fields that have a value. Click edit to change.',
+    fullWidth: true,
+    children: [
+      { name: 'firstName', fieldOptions: { label: 'First Name' } },
+      { name: 'lastName', fieldOptions: { label: 'Last Name' } },
+      { name: 'email', fieldOptions: { label: 'Email' } },
+    ],
+  },
+  {
+    fieldOptions: { label: 'Address' },
+    type: 'heading',
+    name: 'address',
+    fullWidth: true,
+    children: [
+      { name: 'street', fieldOptions: { label: 'Street' }, minOccurs: 0 },
+      { name: 'city', fieldOptions: { label: 'City' }, minOccurs: 0 },
+      { name: 'country', fieldOptions: { label: 'Country' }, minOccurs: 0 },
+    ],
+  },
+], undefined, {
+  initialEdit: false,
+  hideFieldsWithoutValue: true,
+  initialValues: {
+    person: {
+      firstName: 'Jack',
+      lastName: 'Smit',
+    },
+  },
+});
+
 export const individualTestCase = createTestCase(
   [{
     name: 'items',
@@ -113,8 +149,13 @@ export const individualTestCase = createTestCase(
 export function createTestCase(
   metadata: Metadata[],
   settings?: DynamicFormSettings,
+  testCaseConfig: {
+    initialEdit?: boolean
+    hideFieldsWithoutValue?: boolean
+    initialValues?: GenericObject
+  } = {},
 ) {
   return markRaw(defineComponent({
-    render: () => h(TestForm, { metadata, settings, showDebugState: true }),
+    render: () => h(TestForm, { ...testCaseConfig, metadata, settings, showDebugState: true }),
   }));
 }

--- a/packages/core/src/types/FieldMetadata.ts
+++ b/packages/core/src/types/FieldMetadata.ts
@@ -167,8 +167,9 @@ export type FieldMetadata<
    * @returns A transformed FieldMetadata
    */
   computedProps?: ((
-    thisField: ComputedPropsType<FieldMetadata<ExtendedFieldTypes, ExtendedProperties>>,
+    thisField: ComputedPropsType<ExtendedFieldTypes, ExtendedProperties>,
     fieldValue: Ref<unknown>,
+    childFields: Ref<Readonly<FieldMetadata<ExtendedFieldTypes, ExtendedProperties>>[]>,
   ) => void)[]
   /**
    * Normally the computedProps are not re-calculate if a child value changes. If you need this functionality, you can enable this by
@@ -177,10 +178,15 @@ export type FieldMetadata<
   computeOnChildValueChange?: boolean
 } & ExtendedProperties;
 
-export type ComputedPropsType<T> = Omit<
-      T,
-      | 'name' // At this point name will always be present, so remove it as being optional
-      | 'path' // At this point name will always be present, so remove it as being optional
+export type ComputedPropsType<
+  ExtendedFieldTypes extends string = string,
+  ExtendedProperties extends object = object,
+> = Omit<
+      FieldMetadata<ExtendedFieldTypes, ExtendedProperties>,
+      // Remove name, path and parent and add them as reference only and not to be updated
+      | 'name'
+      | 'path'
+      | 'parent'
       // Not allowed to change the children, choice or attributes of this field, create a transform for those fields specifically
       | 'children'
       | 'choice'
@@ -190,13 +196,17 @@ export type ComputedPropsType<T> = Omit<
       | 'fieldOptions'
       // Not allowed to update any of the following values, as they're used initially and are not listened to reactively
       | 'computedProps'
-      // Changing the maxOccurs changes the item in an array item, this is not allowed. MinOccurs is ok, as it only affects wheter
+      // Changing the maxOccurs changes the item in an array item, this is not allowed. MinOccurs is ok, as it only affects whether
       // the item is required.
       | 'maxOccurs'
+      // Not allowed to update the following values as they aren't read from the computedField, but the prop field
+      | 'isComplexType'
+      | 'computeOnChildValueChange'
     > & Readonly<{
       // Add the name & path back as not optional and Readonly
       name: string
       path: string
+      parent: FieldMetadata<ExtendedFieldTypes, ExtendedProperties>
     }>;
 
 export type TemplatePropsType<T> = Omit<

--- a/packages/core/src/types/InternalFieldMetadata.ts
+++ b/packages/core/src/types/InternalFieldMetadata.ts
@@ -4,4 +4,10 @@ import type { RequireOnly } from '@/types/RequireOnly.js';
 export type InternalFieldMetadata<Metadata extends FieldMetadata> = RequireOnly<
   Metadata,
   'name' | 'type' | 'minOccurs' | 'maxOccurs'
->;
+> & {
+  /**
+   * Internal hash computed by the system to track meaningful changes to the computed field.
+   * Do not set this manually — it is overwritten after every computedProps run.
+   */
+  _hash?: string
+};

--- a/packages/core/src/utils/__tests__/mapEachMetadataItem.test.ts
+++ b/packages/core/src/utils/__tests__/mapEachMetadataItem.test.ts
@@ -1,0 +1,97 @@
+import type { GetMetadataType } from '@/types/GetMetadataType';
+import { describe, expect, it } from 'vitest';
+import { defineMetadata } from '@/core/defineMetadata';
+import { mapEachMetadataItem } from '@/utils/mapEachMetadataItem';
+
+export type TestMetadata = GetMetadataType<typeof _metadata>;
+
+const _metadata = defineMetadata<
+  {
+    text: string
+  },
+  {
+    visited?: boolean
+    visitOrder?: number
+  }
+>();
+
+describe('mapEachMetadataItem', () => {
+  it('returns the original metadata when no metadata is provided', () => {
+    expect(mapEachMetadataItem(undefined as never, item => item)).toBeUndefined();
+  });
+
+  it('returns the original metadata when no callback is provided', () => {
+    const metadata: TestMetadata = { name: 'root', type: 'text' };
+    expect(mapEachMetadataItem(metadata, undefined as never)).toBe(metadata);
+  });
+
+  it('maps root, children and choice items recursively in traversal order', () => {
+    let visitOrder = 0;
+    const metadata: TestMetadata = {
+      name: 'root',
+      type: 'text',
+      children: [
+        {
+          name: 'child',
+          type: 'text',
+          choice: [
+            { name: 'grandchild-choice', type: 'text' },
+          ],
+        },
+      ],
+      choice: [
+        { name: 'root-choice', type: 'text' },
+      ],
+    };
+
+    const result = mapEachMetadataItem(metadata, (item) => {
+      item.visited = true;
+      item.visitOrder = ++visitOrder;
+      return item;
+    });
+
+    expect(result).toEqual({
+      name: 'root',
+      type: 'text',
+      visited: true,
+      visitOrder: 1,
+      children: [
+        {
+          name: 'child',
+          type: 'text',
+          visited: true,
+          visitOrder: 2,
+          choice: [
+            { name: 'grandchild-choice', type: 'text', visited: true, visitOrder: 3 },
+          ],
+        },
+      ],
+      choice: [
+        { name: 'root-choice', type: 'text', visited: true, visitOrder: 4 },
+      ],
+    });
+  });
+
+  it('passes a shallow clone to the callback and leaves the original tree unchanged', () => {
+    const metadata: TestMetadata = {
+      name: 'root',
+      type: 'text',
+      children: [{ name: 'child', type: 'text' }],
+    };
+
+    const callbackItems: TestMetadata[] = [];
+    mapEachMetadataItem(metadata, (item) => {
+      callbackItems.push(item);
+      item.visited = true;
+      return item;
+    });
+
+    expect(callbackItems[0]).not.toBe(metadata);
+    expect(callbackItems[1]).not.toBe(metadata.children?.[0]);
+    expect(metadata).toEqual({
+      name: 'root',
+      type: 'text',
+      children: [{ name: 'child', type: 'text' }],
+    });
+  });
+});

--- a/packages/core/src/utils/hashField.ts
+++ b/packages/core/src/utils/hashField.ts
@@ -1,0 +1,29 @@
+import type { FieldMetadata } from '@/types/FieldMetadata';
+
+/**
+ * Creates a deterministic hash of all mutable field properties (those that computedProps can change).
+ * Excludes structural/immutable properties: name, path, children, choice, attributes,
+ * fieldOptions, computedProps, maxOccurs, parent, and _hash itself.
+ */
+export function hashField(field: FieldMetadata): string {
+  const {
+    name: _name,
+    path: _path,
+    children: _children,
+    choice: _choice,
+    attributes: _attributes,
+    fieldOptions: _fieldOptions,
+    computedProps: _computedProps,
+    maxOccurs: _maxOccurs,
+    _hash: _prevHash,
+    parent: _parent,
+    isComplexType: _isComplexType,
+    computeOnChildValueChange: _computeOnChildValueChange,
+    ...mutableProps
+  } = field as any;
+
+  const sorted = Object.fromEntries(
+    Object.entries(mutableProps).sort(([a], [b]) => a.localeCompare(b)),
+  );
+  return JSON.stringify(sorted);
+}

--- a/packages/core/src/utils/mapEachMetadataItem.ts
+++ b/packages/core/src/utils/mapEachMetadataItem.ts
@@ -1,0 +1,25 @@
+import type { FieldMetadata } from '@/types/FieldMetadata';
+
+/**
+ * Recursively walks a `FieldMetadata` tree (visiting `children` and `choice`) and applies
+ * `callbackFunc` to every node, returning the transformed tree.
+ *
+ * The callback receives a shallow clone of each node, so mutations inside the callback do not
+ * affect the original metadata. `children` and `choice` on the returned node are replaced with
+ * the recursively-mapped results after the callback runs.
+ */
+export function mapEachMetadataItem<
+  ExtendedFieldTypes extends string = string,
+  ExtendedProperties extends object = object,
+>(
+  metadata: FieldMetadata<ExtendedFieldTypes, ExtendedProperties>,
+  callbackFunc: (item: FieldMetadata<ExtendedFieldTypes, ExtendedProperties>) => FieldMetadata<ExtendedFieldTypes, ExtendedProperties>,
+): FieldMetadata<ExtendedFieldTypes, ExtendedProperties> {
+  if (!metadata || !callbackFunc)
+    return metadata;
+
+  metadata = callbackFunc?.({ ...metadata });
+  metadata.children = metadata?.children?.map(x => mapEachMetadataItem(x, callbackFunc));
+  metadata.choice = metadata?.choice?.map(x => mapEachMetadataItem(x, callbackFunc));
+  return metadata;
+}

--- a/playgrounds/storybook/stories/TestCases.stories.ts
+++ b/playgrounds/storybook/stories/TestCases.stories.ts
@@ -1,20 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/vue3-vite';
 
-import { arrayTestCase, choiceTestCase, defaultTestCase, groupTestCase, individualTestCase } from '@bach.software/vue-dynamic-form/examples';
-
-import { configure } from 'vee-validate';
-
-/**
- * This should live in the app entry, not here (normally)
- */
-// configure({
-//   generateMessage: (context) => {
-//     if (context.rule?.name === 'xsd_required')
-//       return `The field ${context.field} is required`;
-
-//     return `The field ${context.field} is invalid - Jeroen`;
-//   },
-// });
+import { arrayTestCase, childFieldsTestCase, choiceTestCase, defaultTestCase, groupTestCase, individualTestCase } from '@bach.software/vue-dynamic-form/examples';
 
 const meta = {
   title: 'Forms/TestCases',
@@ -51,6 +37,13 @@ export const GroupFields: Story = {
 export const ChoiceFields: Story = {
   render: () => ({
     components: { TestCase: choiceTestCase },
+    template: `<TestCase />`,
+  }),
+};
+
+export const ChildFieldsTestCase: Story = {
+  render: () => ({
+    components: { TestCase: childFieldsTestCase },
     template: `<TestCase />`,
   }),
 };


### PR DESCRIPTION
- Pass a childFields ref as the third argument to computedProps functions,  allowing parent fields to react to their children's computed state (e.g. hiding a parent when all children are hidden).
- Updated tests
- Updated documentation